### PR TITLE
Fix Vite config imports to enable build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
 export default defineConfig({
   base: '/lingua-avventura/', // ⚠️ usa el nombre de tu repo exacto
   plugins: [react()],


### PR DESCRIPTION
## Summary
- import `defineConfig` from `vite` and `react` plugin for proper configuration

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895d4729e408331b8a3c2d99254dcde