### PR TITLE
Ensure game page builds alongside index

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,17 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: '/lingua-avventura/', // ⚠️ usa el nombre de tu repo exacto
   plugins: [react()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        game: resolve(__dirname, 'game.html'),
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- include `game.html` as an additional entry point in Vite
- add build configuration so `game.html` is output in the dist folder

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895d7611f788331a9619112c9f3b3b6