### PR TITLE
refactor: centralize todayStr utility

### DIFF
--- a/src/hooks/useProgress.js
+++ b/src/hooks/useProgress.js
@@ -1,12 +1,10 @@
 import { useEffect, useState } from 'react'
 import { createDataService, defaultState } from '../services/dataService'
+import { todayStr } from '../utils/date'
 
 const svc = createDataService()
 
-export function todayStr(){
-  const d=new Date();
-  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
-}
+export { todayStr }
 
 export function useProgress(){
   const [progress, setProgress] = useState(() => svc.loadProgress() || defaultState)

--- a/src/services/dataService.js
+++ b/src/services/dataService.js
@@ -13,12 +13,9 @@
  * - resetAll()
  */
 
-const LS_KEY = 'lingua_avventura_progress_v1';
+import { todayStr } from '../utils/date'
 
-function todayStr(){
-  const d=new Date();
-  return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
-}
+const LS_KEY = 'lingua_avventura_progress_v1';
 
 export const defaultState = {
   createdAt: todayStr(),

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,4 @@
+export function todayStr() {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}


### PR DESCRIPTION
## Summary
- add shared `todayStr` helper in `src/utils/date.js`
- reuse `todayStr` in `useProgress` and `dataService`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896360759988331826311bd6c66cf8d