### PR TITLE
feat: allow pluggable data backends

### DIFF
--- a/src/hooks/useProgress.js
+++ b/src/hooks/useProgress.js
@@ -1,16 +1,15 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { createDataService, defaultState } from '../services/dataService'
 import { todayStr } from '../utils/date'
 
-const svc = createDataService()
-
 export { todayStr }
 
-export function useProgress(){
+export function useProgress({ backend, dataService } = {}){
+  const svc = useMemo(() => dataService || createDataService(backend), [backend, dataService])
   const [progress, setProgress] = useState(() => svc.loadProgress() || defaultState)
 
   // Sincroniza al montar (por si cambió la racha)
-  useEffect(()=>{ setProgress(svc.loadProgress()) }, [])
+  useEffect(()=>{ setProgress(svc.loadProgress()) }, [svc])
 
   const awardXP = (amount)=> setProgress(prev=> ({...svc.awardXP({...prev}, amount)}))
   const incrementCompletion = (key, by=1)=> setProgress(prev=> ({...svc.incrementCompletion({...prev}, key, by)}))

--- a/src/services/dataService.js
+++ b/src/services/dataService.js
@@ -40,7 +40,7 @@ function daysBetween(a,b){
 }
 
 /** LocalStorage backend */
-function createLocalStorageBackend(){
+export function createLocalStorageBackend(){
   return {
     load(){
       try { const raw = localStorage.getItem(LS_KEY); return raw? JSON.parse(raw): null; } catch { return null; }
@@ -55,7 +55,7 @@ function createLocalStorageBackend(){
 }
 
 /** Firebase backend (stub) — implementa estos 3 métodos mañana */
-function createFirebaseBackend(){
+export function createFirebaseBackend(){
   return {
     load(){ throw new Error('TODO: implementar Firebase.load()'); },
     save(){ throw new Error('TODO: implementar Firebase.save()'); },
@@ -63,10 +63,7 @@ function createFirebaseBackend(){
   }
 }
 
-/** Selector de backend */
-const backend = createLocalStorageBackend(); // <- cambia a createFirebaseBackend() cuando esté listo
-
-export function createDataService(){
+export function createDataService(backend = createLocalStorageBackend()){
   return {
     loadProgress(){
       const state = backend.load() || defaultState;


### PR DESCRIPTION
## Summary
- make data service accept custom backend and expose backend factories
- allow useProgress hook to inject backend or data service for easier testing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689638353b9c83318beae7ab8ae97747