### PR TITLE
refactor: centralize speech synthesis utility

### DIFF
--- a/src/components/DailyReview.jsx
+++ b/src/components/DailyReview.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react'
 import Card from './Card'
-import { speak } from '../services/speech'
+import { speak } from '../utils/speech'
 
 export default function DailyReview({ pack, onComplete, lang, awardXP }){
   const [qIdx, setQIdx] = useState(0)

--- a/src/components/Flashcards.jsx
+++ b/src/components/Flashcards.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import Card from './Card'
-import { speak } from '../services/speech'
+import { speak } from '../utils/speech'
 
 export default function Flashcards({ pack, onComplete, onLearned, lang }){
   const [idx, setIdx] = useState(0)

--- a/src/components/MouseAndCheese.jsx
+++ b/src/components/MouseAndCheese.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import Card from './Card'
 import Chip from './Chip'
-import { speak } from '../services/speech'
+import { speak } from '../utils/speech'
 
 export default function MouseAndCheese({ pack, onEatCheese, lang }){
   const canvasRef = useRef(null)

--- a/src/components/Quiz.jsx
+++ b/src/components/Quiz.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from 'react'
 import Card from './Card'
-import { speak } from '../services/speech'
+import { speak } from '../utils/speech'
 
 const SUBTITLE_MAP = {
   it: 'Traduce del italiano al español',

--- a/src/utils/speech.js
+++ b/src/utils/speech.js
@@ -1,15 +1,24 @@
 const VOICE_MAP = { it: 'it-IT', fr: 'fr-FR', en: 'en-US' }
+let voices = []
+
+if (typeof window !== 'undefined' && 'speechSynthesis' in window){
+  const synth = window.speechSynthesis
+  const populate = () => { voices = synth.getVoices() }
+  populate()
+  synth.addEventListener('voiceschanged', populate)
+}
+
 export function speak(text, lang = 'it'){
   if (typeof window === 'undefined' || !('speechSynthesis' in window)) return
+  const synth = window.speechSynthesis
   const utter = new SpeechSynthesisUtterance(text)
   const locale = VOICE_MAP[lang] || VOICE_MAP.it
   utter.lang = locale
   utter.rate = 0.95
   utter.pitch = 1.0
-  const synth = window.speechSynthesis
-  const voices = synth.getVoices()
+  if(!voices.length) voices = synth.getVoices()
   const match = voices.find(v => v.lang?.toLowerCase().startsWith(locale.toLowerCase()))
-  if (match) utter.voice = match
+  if(match) utter.voice = match
   synth.cancel()
   synth.speak(utter)
 }


### PR DESCRIPTION
## Summary
- Add `utils/speech.js` to handle speech synthesis with `voiceschanged` event support
- Update components to import `speak` from the new utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896391ecb8483318ec16e621b88a04a