### PR TITLE
feat: introduce reusable Button component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Quiz from './components/Quiz'
 import Matching from './components/Matching'
 import DailyReview from './components/DailyReview'
 import MouseAndCheese from './components/MouseAndCheese'
+import Button from './components/Button'
 import { getPack } from './data/packs'
 
 export default function App(){
@@ -38,7 +39,7 @@ export default function App(){
               <option value="fr">Narración: Francés</option>
               <option value="en">Narración: Inglés</option>
             </select>
-            <button className="px-3 py-2 rounded-xl border border-neutral-200 hover:bg-neutral-50" onClick={resetAll}>Reiniciar progreso</button>
+            <Button variant="outline" className="px-3" onClick={resetAll}>Reiniciar progreso</Button>
           </div>
         </div>
       </header>

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const VARIANTS = {
+  primary: 'bg-emerald-600 text-white hover:bg-emerald-700',
+  secondary: 'bg-neutral-100 text-neutral-900 hover:bg-neutral-200',
+  outline: 'bg-white border border-neutral-200 hover:bg-neutral-50'
+}
+
+export default function Button({ variant = 'primary', className = '', ...props }){
+  const base = 'px-4 py-2 rounded-xl transition'
+  const variantClasses = VARIANTS[variant] || ''
+  return (
+    <button className={`${base} ${variantClasses} ${className}`} {...props} />
+  )
+}

--- a/src/components/DailyReview.jsx
+++ b/src/components/DailyReview.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react'
 import Card from './Card'
+import Button from './Button'
 import { speak } from '../utils/speech'
 
 export default function DailyReview({ pack, onComplete, lang, awardXP }){
@@ -23,9 +24,9 @@ export default function DailyReview({ pack, onComplete, lang, awardXP }){
       <div className="text-2xl font-semibold mb-2">{q.prompt}</div>
       <div className="flex gap-2 mb-2">
         <input value={answer} onChange={e=>setAnswer(e.target.value)} placeholder="Escribe en español" className="flex-1 px-3 py-2 rounded-xl border border-neutral-300" />
-        <button className="px-4 py-2 rounded-xl bg-emerald-600 text-white hover:bg-emerald-700" onClick={check}>Comprobar</button>
+        <Button onClick={check}>Comprobar</Button>
       </div>
-      <button className="px-3 py-2 rounded-xl border border-neutral-200 hover:bg-neutral-50" onClick={()=>speak(q.prompt, lang)}>Escuchar</button>
+      <Button variant="outline" className="px-3" onClick={()=>speak(q.prompt, lang)}>Escuchar</Button>
     </Card>
   )
 }

--- a/src/components/Flashcards.jsx
+++ b/src/components/Flashcards.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import Card from './Card'
+import Button from './Button'
 import { speak } from '../utils/speech'
 
 export default function Flashcards({ pack, onComplete, onLearned, lang }){
@@ -20,9 +21,9 @@ export default function Flashcards({ pack, onComplete, onLearned, lang }){
           </div>
         </div>
         <div className="flex gap-2">
-          <button className="px-4 py-2 rounded-xl border border-neutral-200 hover:bg-neutral-50" onClick={()=>setFlipped(!flipped)}>Voltear</button>
-          <button className="px-4 py-2 rounded-xl bg-emerald-600 text-white hover:bg-emerald-700" onClick={onSpeak}>Escuchar</button>
-          <button className="px-4 py-2 rounded-xl border border-neutral-200 hover:bg-neutral-50" onClick={next}>Siguiente</button>
+          <Button variant="outline" onClick={()=>setFlipped(!flipped)}>Voltear</Button>
+          <Button onClick={onSpeak}>Escuchar</Button>
+          <Button variant="outline" onClick={next}>Siguiente</Button>
         </div>
       </Card>
       <Card title="Consejo" subtitle="Pronunciación">

--- a/src/components/MouseAndCheese.jsx
+++ b/src/components/MouseAndCheese.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import Card from './Card'
 import Chip from './Chip'
+import Button from './Button'
 import { speak } from '../utils/speech'
 
 export default function MouseAndCheese({ pack, onEatCheese, lang }){
@@ -84,7 +85,7 @@ export default function MouseAndCheese({ pack, onEatCheese, lang }){
     <Card title="Topo & Formaggio" subtitle="Usa las flechas. Come queso para oír nuevas palabras.">
       <div className="flex items-center gap-2 mb-2">
         <Chip>{running? 'En juego':'Game Over'}</Chip>
-        <button className="px-3 py-2 rounded-xl border border-neutral-200 hover:bg-neutral-50" onClick={()=>setRunning(r=>!r)}>{running? 'Pausar':'Reiniciar'}</button>
+        <Button variant="outline" className="px-3" onClick={()=>setRunning(r=>!r)}>{running? 'Pausar':'Reiniciar'}</Button>
       </div>
       <canvas ref={canvasRef} width={28*grid} height={20*grid} className="rounded-2xl border-4 border-amber-700 bg-emerald-100"/>
       <p className="text-sm text-neutral-600 mt-2">Consejo: repite en voz alta la palabra. 🎧</p>

--- a/src/components/Quiz.jsx
+++ b/src/components/Quiz.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react'
 import Card from './Card'
+import Button from './Button'
 import { speak } from '../utils/speech'
 
 const SUBTITLE_MAP = {
@@ -33,12 +34,19 @@ export default function Quiz({ pack, onComplete, onLearned, lang, awardXP }){
       <div className="mb-3 text-2xl font-semibold">{q.prompt}</div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
         {q.options.map(opt=> (
-          <button key={opt} className={`px-4 py-3 rounded-xl border text-left ${selected===opt ? (opt===q.correct? 'bg-emerald-100 border-emerald-400':'bg-rose-100 border-rose-400'): 'bg-white border-neutral-200 hover:bg-neutral-50'}`} onClick={()=>select(opt)}>{opt}</button>
+          <Button
+            key={opt}
+            variant="outline"
+            className={`py-3 text-left ${selected===opt ? (opt===q.correct? 'bg-emerald-100 border-emerald-400':'bg-rose-100 border-rose-400') : ''}`}
+            onClick={()=>select(opt)}
+          >
+            {opt}
+          </Button>
         ))}
       </div>
       <div className="mt-3 flex gap-2">
-        <button className="px-4 py-2 rounded-xl border border-neutral-200 hover:bg-neutral-50" onClick={()=>speak(q.prompt, lang)}>Escuchar</button>
-        <button className="px-4 py-2 rounded-xl bg-emerald-600 text-white hover:bg-emerald-700" onClick={next}>Continuar</button>
+        <Button variant="outline" onClick={()=>speak(q.prompt, lang)}>Escuchar</Button>
+        <Button onClick={next}>Continuar</Button>
       </div>
     </Card>
   )


### PR DESCRIPTION
## Summary
- add Button component with primary, secondary, and outline variants
- refactor App, Flashcards, Quiz, DailyReview, and MouseAndCheese to use new Button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68963c50f1cc83319e569c6e4e266da5