### PR TITLE
feat: add 3D flip animation to flashcards

### DIFF
--- a/src/components/Flashcards.jsx
+++ b/src/components/Flashcards.jsx
@@ -16,8 +16,13 @@ export default function Flashcards({ pack, onComplete, onLearned, lang }){
     <div className="grid md:grid-cols-2 gap-4">
       <Card title="Flashcard" subtitle="Pulsa para voltear o escuchar">
         <div className="h-48 flex items-center justify-center">
-          <div className={`w-full h-40 rounded-2xl border border-neutral-200 flex items-center justify-center text-2xl font-semibold select-none ${flipped? 'bg-amber-50':'bg-white'}`} onClick={()=>setFlipped(!flipped)}>
-            {flipped ? <span>{current.es}</span> : <span>{frontText}</span>}
+          <div className="perspective w-full h-40">
+            <div
+              className={`flip-card w-full h-full rounded-2xl border border-neutral-200 flex items-center justify-center text-2xl font-semibold select-none ${flipped ? 'flipped bg-amber-50' : 'bg-white'}`}
+              onClick={()=>setFlipped(!flipped)}
+            >
+              {flipped ? <span>{current.es}</span> : <span>{frontText}</span>}
+            </div>
           </div>
         </div>
         <div className="flex gap-2">

--- a/src/index.css
+++ b/src/index.css
@@ -4,3 +4,17 @@
 
 html, body, #root { height: 100%; }
 body { @apply bg-amber-50 text-neutral-900; }
+
+.perspective {
+  perspective: 1000px;
+}
+
+.flip-card {
+  transform-style: preserve-3d;
+  transition: transform 0.6s;
+  transform: rotateY(0deg);
+}
+
+.flip-card.flipped {
+  transform: rotateY(180deg);
+}


### PR DESCRIPTION
## Summary
- add perspective container for flashcards and flip animation
- style flip-card class with 3D rotation and transition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68963dfb5af88331bd2d0ec66f295d49