### PR TITLE
feat: add dark mode support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ import { getPack } from './data/packs'
 export default function App(){
   const { progress, awardXP, incrementCompletion, markLearned, setNarrationMode, resetAll } = useProgress()
   const [tab, setTab] = useState('dashboard')
+  const [dark, setDark] = useState(false)
   const lang = progress.settings.narrationMode
   const pack = getPack(lang)
 
@@ -25,60 +26,63 @@ export default function App(){
   const onEatCheese = (word)=>{ incrementCompletion('gameCheeseEaten'); markLearned(word) }
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-amber-50 to-emerald-50 text-neutral-900">
-      <header className="sticky top-0 z-10 backdrop-blur bg-white/70 border-b border-neutral-200">
-        <div className="max-w-6xl mx-auto p-4 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <span className="text-2xl">🍝</span>
-            <h1 className="text-xl md:text-2xl font-extrabold tracking-tight">Lingua Avventura</h1>
-            <Chip>Idiomas para hispanohablantes</Chip>
+    <div className={dark ? 'dark' : ''}>
+      <div className="min-h-screen bg-gradient-to-b from-amber-50 to-emerald-50 text-neutral-900 dark:from-neutral-900 dark:to-neutral-900 dark:text-neutral-100">
+        <header className="sticky top-0 z-10 backdrop-blur bg-white/70 border-b border-neutral-200 dark:bg-neutral-800/70 dark:border-neutral-700">
+          <div className="max-w-6xl mx-auto p-4 flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <span className="text-2xl">🍝</span>
+              <h1 className="text-xl md:text-2xl font-extrabold tracking-tight">Lingua Avventura</h1>
+              <Chip>Idiomas para hispanohablantes</Chip>
+            </div>
+            <div className="flex items-center gap-2">
+              <select className="px-3 py-2 rounded-xl border border-neutral-300 bg-white dark:bg-neutral-700 dark:border-neutral-600 dark:text-neutral-100" value={lang} onChange={e=>setNarrationMode(e.target.value)}>
+                <option value="it">Narración: Italiano</option>
+                <option value="fr">Narración: Francés</option>
+                <option value="en">Narración: Inglés</option>
+              </select>
+              <Button variant="outline" className="px-3" onClick={resetAll}>Reiniciar progreso</Button>
+              <Button variant="outline" className="px-3" onClick={()=>setDark(d=>!d)}>{dark ? 'Modo claro' : 'Modo oscuro'}</Button>
+            </div>
           </div>
-          <div className="flex items-center gap-2">
-            <select className="px-3 py-2 rounded-xl border border-neutral-300 bg-white" value={lang} onChange={e=>setNarrationMode(e.target.value)}>
-              <option value="it">Narración: Italiano</option>
-              <option value="fr">Narración: Francés</option>
-              <option value="en">Narración: Inglés</option>
-            </select>
-            <Button variant="outline" className="px-3" onClick={resetAll}>Reiniciar progreso</Button>
-          </div>
-        </div>
-      </header>
+        </header>
 
-      <main className="max-w-6xl mx-auto p-4">
-        <Tabs tabs={[
-          { value: 'dashboard', label: 'Inicio' },
-          { value: 'flash', label: 'Flashcards' },
-          { value: 'quiz', label: 'Quiz' },
-          { value: 'match', label: 'Memoria' },
-          { value: 'review', label: 'Revisión' },
-          { value: 'game', label: 'Juego 🧀' },
-        ]} value={tab} onChange={setTab} />
+        <main className="max-w-6xl mx-auto p-4">
+          <Tabs tabs={[
+            { value: 'dashboard', label: 'Inicio' },
+            { value: 'flash', label: 'Flashcards' },
+            { value: 'quiz', label: 'Quiz' },
+            { value: 'match', label: 'Memoria' },
+            { value: 'review', label: 'Revisión' },
+            { value: 'game', label: 'Juego 🧀' },
+          ]} value={tab} onChange={setTab} />
 
-        {tab==='dashboard' && <Dashboard progress={progress} />}
-        {tab==='flash' && <Flashcards pack={pack} lang={lang} onComplete={onFlashcardsComplete} onLearned={markLearned} />}
-        {tab==='quiz' && <Quiz pack={pack} lang={lang} onComplete={onQuizComplete} onLearned={markLearned} awardXP={awardXP} />}
-        {tab==='match' && <Matching pack={pack} lang={lang} onComplete={onMatchingComplete} onLearned={markLearned} />}
-        {tab==='review' && <DailyReview pack={pack} lang={lang} onComplete={onReviewComplete} awardXP={awardXP} />}
-        {tab==='game' && <MouseAndCheese pack={pack} lang={lang} onEatCheese={onEatCheese} />}
+          {tab==='dashboard' && <Dashboard progress={progress} />}
+          {tab==='flash' && <Flashcards pack={pack} lang={lang} onComplete={onFlashcardsComplete} onLearned={markLearned} />}
+          {tab==='quiz' && <Quiz pack={pack} lang={lang} onComplete={onQuizComplete} onLearned={markLearned} awardXP={awardXP} />}
+          {tab==='match' && <Matching pack={pack} lang={lang} onComplete={onMatchingComplete} onLearned={markLearned} />}
+          {tab==='review' && <DailyReview pack={pack} lang={lang} onComplete={onReviewComplete} awardXP={awardXP} />}
+          {tab==='game' && <MouseAndCheese pack={pack} lang={lang} onEatCheese={onEatCheese} />}
 
-        <section className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Card title="Consejo del día" subtitle="Hábitos que funcionan">
-            <ul className="list-disc ml-5 text-sm text-neutral-700 space-y-1">
-              <li>Estudia 10–15 min diarios para mantener la racha.</li>
-              <li>Repite en voz alta y grábate para comparar.</li>
-              <li>Varía actividades: tarjetas, quiz, juego.</li>
-            </ul>
-          </Card>
-          <Card title="Meta diaria" subtitle="Objetivo sugerido">
-            <p className="text-sm">Aprender 5 palabras nuevas y jugar 1 partida de Topo & Formaggio.</p>
-          </Card>
-          <Card title="Acerca del paquete" subtitle="Personalizable">
-            <p className="text-sm">Amplía vocabulario editando los paquetes en <code>src/data/packs.js</code>. La narración usa SpeechSynthesis (voz del sistema).</p>
-          </Card>
-        </section>
-      </main>
+          <section className="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <Card title="Consejo del día" subtitle="Hábitos que funcionan">
+              <ul className="list-disc ml-5 text-sm text-neutral-700 dark:text-neutral-300 space-y-1">
+                <li>Estudia 10–15 min diarios para mantener la racha.</li>
+                <li>Repite en voz alta y grábate para comparar.</li>
+                <li>Varía actividades: tarjetas, quiz, juego.</li>
+              </ul>
+            </Card>
+            <Card title="Meta diaria" subtitle="Objetivo sugerido">
+              <p className="text-sm">Aprender 5 palabras nuevas y jugar 1 partida de Topo & Formaggio.</p>
+            </Card>
+            <Card title="Acerca del paquete" subtitle="Personalizable">
+              <p className="text-sm">Amplía vocabulario editando los paquetes en <code>src/data/packs.js</code>. La narración usa SpeechSynthesis (voz del sistema).</p>
+            </Card>
+          </section>
+        </main>
 
-      <footer className="max-w-6xl mx-auto p-4 text-center text-xs text-neutral-500">Hecho con ❤️ para aprender idiomas — narración disponible en Italiano, Francés e Inglés.</footer>
+        <footer className="max-w-6xl mx-auto p-4 text-center text-xs text-neutral-500 dark:text-neutral-400">Hecho con ❤️ para aprender idiomas — narración disponible en Italiano, Francés e Inglés.</footer>
+      </div>
     </div>
   )
 }

--- a/src/components/Button.jsx
+++ b/src/components/Button.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
 const VARIANTS = {
-  primary: 'bg-emerald-600 text-white hover:bg-emerald-700',
-  secondary: 'bg-neutral-100 text-neutral-900 hover:bg-neutral-200',
-  outline: 'bg-white border border-neutral-200 hover:bg-neutral-50'
+  primary: 'bg-emerald-600 text-white hover:bg-emerald-700 dark:bg-emerald-700 dark:hover:bg-emerald-600',
+  secondary: 'bg-neutral-100 text-neutral-900 hover:bg-neutral-200 dark:bg-neutral-700 dark:text-neutral-100 dark:hover:bg-neutral-600',
+  outline: 'bg-white border border-neutral-200 hover:bg-neutral-50 dark:bg-neutral-700 dark:border-neutral-600 dark:hover:bg-neutral-600 dark:text-neutral-100'
 }
 
 export default function Button({ variant = 'primary', className = '', ...props }){

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -3,17 +3,17 @@ import React from 'react'
 export default function Card({ title, subtitle, children, footer, onClick }){
   return (
     <div
-      className={`rounded-2xl shadow-md bg-white/90 backdrop-blur border border-neutral-200 p-4 hover:shadow-lg transition ${onClick ? 'cursor-pointer' : 'cursor-default'}`}
+      className={`rounded-2xl shadow-md bg-white/90 dark:bg-neutral-800/90 backdrop-blur border border-neutral-200 dark:border-neutral-700 p-4 hover:shadow-lg transition ${onClick ? 'cursor-pointer' : 'cursor-default'}`}
       onClick={onClick}
     >
       {title && (
         <div className="mb-2">
           <h3 className="text-lg font-semibold">{title}</h3>
-          {subtitle && <p className="text-sm text-neutral-500">{subtitle}</p>}
+          {subtitle && <p className="text-sm text-neutral-500 dark:text-neutral-400">{subtitle}</p>}
         </div>
       )}
       <div>{children}</div>
-      {footer && <div className="mt-3 text-sm text-neutral-600">{footer}</div>}
+      {footer && <div className="mt-3 text-sm text-neutral-600 dark:text-neutral-300">{footer}</div>}
     </div>
   )
 }

--- a/src/components/Chip.jsx
+++ b/src/components/Chip.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
 
 export default function Chip({ children }){
-  return <span className="inline-block rounded-2xl px-3 py-1 text-xs bg-emerald-100 text-emerald-800 border border-emerald-300">{children}</span>
+  return <span className="inline-block rounded-2xl px-3 py-1 text-xs bg-emerald-100 text-emerald-800 border border-emerald-300 dark:bg-emerald-900 dark:text-emerald-200 dark:border-emerald-700">{children}</span>
 }

--- a/src/components/DailyReview.jsx
+++ b/src/components/DailyReview.jsx
@@ -23,7 +23,7 @@ export default function DailyReview({ pack, onComplete, lang, awardXP }){
     <Card title="Revisión diaria" subtitle="Escribe la traducción al español">
       <div className="text-2xl font-semibold mb-2">{q.prompt}</div>
       <div className="flex gap-2 mb-2">
-        <input value={answer} onChange={e=>setAnswer(e.target.value)} placeholder="Escribe en español" className="flex-1 px-3 py-2 rounded-xl border border-neutral-300" />
+        <input value={answer} onChange={e=>setAnswer(e.target.value)} placeholder="Escribe en español" className="flex-1 px-3 py-2 rounded-xl border border-neutral-300 dark:bg-neutral-800 dark:border-neutral-600 dark:text-neutral-100" />
         <Button onClick={check}>Comprobar</Button>
       </div>
       <Button variant="outline" className="px-3" onClick={()=>speak(q.prompt, lang)}>Escuchar</Button>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -14,22 +14,22 @@ export default function Dashboard({ progress }){
           <div className="text-4xl">🔥</div>
           <div>
             <div className="text-3xl font-bold">{progress.streak}</div>
-            <div className="text-sm text-neutral-600">¡Sigue así!</div>
+            <div className="text-sm text-neutral-600 dark:text-neutral-400">¡Sigue así!</div>
           </div>
         </div>
       </Card>
       <Card title="Nivel" subtitle="Gana XP para subir de nivel">
         <div>
           <div className="text-3xl font-bold mb-2">{level}</div>
-          <div className="w-full h-3 bg-neutral-200 rounded-full overflow-hidden">
+          <div className="w-full h-3 bg-neutral-200 dark:bg-neutral-700 rounded-full overflow-hidden">
             <div className="h-full bg-emerald-500" style={{ width: `${xpInLevel}%` }} />
           </div>
-          <div className="text-sm mt-1 text-neutral-600">{xpInLevel} / 100 XP</div>
+          <div className="text-sm mt-1 text-neutral-600 dark:text-neutral-400">{xpInLevel} / 100 XP</div>
         </div>
       </Card>
       <Card title="Palabras" subtitle="Aprendidas (aprox.)">
         <div className="text-3xl font-bold">{totalWords}</div>
-        <div className="text-sm text-neutral-600">Sigue practicando para consolidar.</div>
+        <div className="text-sm text-neutral-600 dark:text-neutral-400">Sigue practicando para consolidar.</div>
       </Card>
       <Card title="Actividad" subtitle="Resumen rápido" footer={
         <div className="flex flex-wrap gap-2">
@@ -40,7 +40,7 @@ export default function Dashboard({ progress }){
           <Chip>Quesos (juego): {progress.completions.gameCheeseEaten}</Chip>
         </div>
       }>
-        <p className="text-neutral-700">¡Vamos por más! 🍝</p>
+        <p className="text-neutral-700 dark:text-neutral-300">¡Vamos por más! 🍝</p>
       </Card>
     </div>
   )

--- a/src/components/Flashcards.jsx
+++ b/src/components/Flashcards.jsx
@@ -18,7 +18,7 @@ export default function Flashcards({ pack, onComplete, onLearned, lang }){
         <div className="h-48 flex items-center justify-center">
           <div className="perspective w-full h-40">
             <div
-              className={`flip-card w-full h-full rounded-2xl border border-neutral-200 flex items-center justify-center text-2xl font-semibold select-none ${flipped ? 'flipped bg-amber-50' : 'bg-white'}`}
+              className={`flip-card w-full h-full rounded-2xl border border-neutral-200 dark:border-neutral-700 flex items-center justify-center text-2xl font-semibold select-none ${flipped ? 'flipped bg-amber-50 dark:bg-neutral-700' : 'bg-white dark:bg-neutral-800'} dark:text-neutral-100`}
               onClick={()=>setFlipped(!flipped)}
             >
               {flipped ? <span>{current.es}</span> : <span>{frontText}</span>}
@@ -32,7 +32,7 @@ export default function Flashcards({ pack, onComplete, onLearned, lang }){
         </div>
       </Card>
       <Card title="Consejo" subtitle="Pronunciación">
-        <p className="text-neutral-700">Repite en voz alta 3 veces. Imita ritmo y entonación.</p>
+        <p className="text-neutral-700 dark:text-neutral-300">Repite en voz alta 3 veces. Imita ritmo y entonación.</p>
       </Card>
     </div>
   )

--- a/src/components/Matching.jsx
+++ b/src/components/Matching.jsx
@@ -27,7 +27,7 @@ export default function Matching({ pack, onComplete, onLearned, lang }){
     <Card title="Memoria" subtitle="Empareja palabra y significado">
       <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
         {items.map(it=> (
-          <button key={it.id} className={`px-3 py-3 rounded-xl border text-left ${removed.includes(it.id)? 'opacity-30 pointer-events-none':'hover:bg-neutral-50'} ${selected?.id===it.id? 'border-emerald-400 bg-emerald-50':'border-neutral-200 bg-white'}`} onClick={()=>click(it)}>{it.text}</button>
+          <button key={it.id} className={`px-3 py-3 rounded-xl border text-left ${removed.includes(it.id)? 'opacity-30 pointer-events-none':'hover:bg-neutral-50 dark:hover:bg-neutral-700'} ${selected?.id===it.id? 'border-emerald-400 bg-emerald-50 dark:border-emerald-600 dark:bg-emerald-900':'border-neutral-200 bg-white dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-100'}`} onClick={()=>click(it)}>{it.text}</button>
         ))}
       </div>
     </Card>

--- a/src/components/MouseAndCheese.jsx
+++ b/src/components/MouseAndCheese.jsx
@@ -87,8 +87,8 @@ export default function MouseAndCheese({ pack, onEatCheese, lang }){
         <Chip>{running? 'En juego':'Game Over'}</Chip>
         <Button variant="outline" className="px-3" onClick={()=>setRunning(r=>!r)}>{running? 'Pausar':'Reiniciar'}</Button>
       </div>
-      <canvas ref={canvasRef} width={28*grid} height={20*grid} className="rounded-2xl border-4 border-amber-700 bg-emerald-100"/>
-      <p className="text-sm text-neutral-600 mt-2">Consejo: repite en voz alta la palabra. 🎧</p>
+      <canvas ref={canvasRef} width={28*grid} height={20*grid} className="rounded-2xl border-4 border-amber-700 bg-emerald-100 dark:border-amber-400 dark:bg-emerald-900"/>
+      <p className="text-sm text-neutral-600 dark:text-neutral-400 mt-2">Consejo: repite en voz alta la palabra. 🎧</p>
     </Card>
   )
 }

--- a/src/components/Quiz.jsx
+++ b/src/components/Quiz.jsx
@@ -37,7 +37,7 @@ export default function Quiz({ pack, onComplete, onLearned, lang, awardXP }){
           <Button
             key={opt}
             variant="outline"
-            className={`py-3 text-left ${selected===opt ? (opt===q.correct? 'bg-emerald-100 border-emerald-400':'bg-rose-100 border-rose-400') : ''}`}
+            className={`py-3 text-left ${selected===opt ? (opt===q.correct? 'bg-emerald-100 border-emerald-400 dark:bg-emerald-900 dark:border-emerald-600':'bg-rose-100 border-rose-400 dark:bg-rose-900 dark:border-rose-600') : ''}`}
             onClick={()=>select(opt)}
           >
             {opt}

--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -4,7 +4,13 @@ export default function Tabs({ tabs, value, onChange }){
   return (
     <div className="flex gap-2 mb-4">
       {tabs.map(t => (
-        <button key={t.value} className={`px-4 py-2 rounded-2xl border ${value===t.value? 'bg-emerald-600 text-white border-emerald-600':'bg-white hover:bg-neutral-50 border-neutral-200'} transition`} onClick={()=>onChange(t.value)}>{t.label}</button>
+        <button
+          key={t.value}
+          className={`px-4 py-2 rounded-2xl border ${value===t.value ? 'bg-emerald-600 text-white border-emerald-600 dark:bg-emerald-700 dark:border-emerald-700' : 'bg-white hover:bg-neutral-50 border-neutral-200 dark:bg-neutral-700 dark:hover:bg-neutral-600 dark:border-neutral-600 dark:text-neutral-100'} transition`}
+          onClick={()=>onChange(t.value)}
+        >
+          {t.label}
+        </button>
       ))}
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 html, body, #root { height: 100%; }
-body { @apply bg-amber-50 text-neutral-900; }
+body { @apply bg-amber-50 text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100; }
 
 .perspective {
   perspective: 1000px;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- enable Tailwind CSS dark mode and body styles
- add dark mode toggle and variants across components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689641eb0fcc8331b656d3fdea3cdd5a