### PR TITLE
feat: add animated tab indicator

### DIFF
--- a/src/components/Tabs.jsx
+++ b/src/components/Tabs.jsx
@@ -1,17 +1,38 @@
 import React from 'react'
 
-export default function Tabs({ tabs, value, onChange }){
+export default function Tabs({ tabs, value, onChange }) {
+  const tabRefs = React.useRef([])
+  const [underlineStyle, setUnderlineStyle] = React.useState({ left: 0, width: 0 })
+
+  const activeIndex = tabs.findIndex(t => t.value === value)
+
+  React.useEffect(() => {
+    const el = tabRefs.current[activeIndex]
+    if (el) {
+      setUnderlineStyle({ left: el.offsetLeft, width: el.offsetWidth })
+    }
+  }, [activeIndex, tabs])
+
   return (
-    <div className="flex gap-2 mb-4">
-      {tabs.map(t => (
+    <div className="relative flex gap-2 mb-4">
+      {tabs.map((t, i) => (
         <button
           key={t.value}
-          className={`px-4 py-2 rounded-2xl border ${value===t.value ? 'bg-emerald-600 text-white border-emerald-600 dark:bg-emerald-700 dark:border-emerald-700' : 'bg-white hover:bg-neutral-50 border-neutral-200 dark:bg-neutral-700 dark:hover:bg-neutral-600 dark:border-neutral-600 dark:text-neutral-100'} transition`}
-          onClick={()=>onChange(t.value)}
+          ref={el => (tabRefs.current[i] = el)}
+          className={`relative px-4 py-2 rounded-2xl border ${
+            value === t.value
+              ? 'bg-emerald-600 text-white border-emerald-600 dark:bg-emerald-700 dark:border-emerald-700'
+              : 'bg-white hover:bg-neutral-50 border-neutral-200 dark:bg-neutral-700 dark:hover:bg-neutral-600 dark:border-neutral-600 dark:text-neutral-100'
+          } transition`}
+          onClick={() => onChange(t.value)}
         >
           {t.label}
         </button>
       ))}
+      <span
+        className="absolute bottom-0 h-0.5 bg-emerald-600 transition-all duration-300"
+        style={{ left: underlineStyle.left, width: underlineStyle.width }}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add relative container with animated underline for tab navigation
- smoothly transition indicator using refs and effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896470bec6483319ee8c5906e17bb35