### PR TITLE
Add local packs API server and hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@ SPA gamificada para aprender italiano (UI en español) con minijuego tipo Snake 
 ## Desarrollo local
 ```bash
 npm install
-npm run dev
+npm run api   # expone la API básica en http://localhost:4000
+npm run dev   # en otra terminal, levanta la SPA
 ```
+
+La aplicación intenta consumir la API de vocabulario en `VITE_PACKS_API_URL` (por defecto `http://localhost:4000`).
+Si la API no está disponible, se mantiene el paquete local definido en `src/data/packs.json`.
 
 ## Build
 ```bash

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "api": "node server/index.js",
     "test": "echo \"No hay pruebas configuradas\" && exit 0"
   },
   "license": "MIT",

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,73 @@
+const http = require("http");
+const packs = require("../src/data/packs.json");
+
+const PORT = process.env.PORT || 4000;
+
+function sendJson(res, statusCode, data) {
+  const payload = JSON.stringify(data);
+  res.writeHead(statusCode, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET,OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  });
+  res.end(payload);
+}
+
+function handleRequest(req, res) {
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET,OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    });
+    res.end();
+    return;
+  }
+
+  if (req.method !== "GET") {
+    sendJson(res, 405, { error: "Método no permitido" });
+    return;
+  }
+
+  const requestUrl = new URL(req.url, "http://localhost");
+  const segments = requestUrl.pathname.split("/").filter(Boolean);
+
+  if (segments.length === 0) {
+    sendJson(res, 200, {
+      message: "API de paquetes Lingua Avventura",
+      routes: ["GET /packs", "GET /packs/:lang"],
+    });
+    return;
+  }
+
+  if (segments[0] !== "packs") {
+    sendJson(res, 404, { error: "Ruta no encontrada" });
+    return;
+  }
+
+  if (segments.length === 1) {
+    sendJson(res, 200, { languages: Object.keys(packs) });
+    return;
+  }
+
+  const lang = segments[1];
+  const pack = packs[lang];
+
+  if (!pack) {
+    sendJson(res, 404, { error: `No existe un paquete para "${lang}"` });
+    return;
+  }
+
+  sendJson(res, 200, { lang, words: pack });
+}
+
+const server = http.createServer(handleRequest);
+
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`API de packs activa en http://localhost:${PORT}`);
+  });
+}
+
+module.exports = server;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { onAuth, logout } from "./services/firebase";
 import LoginForm from "./components/LoginForm";
 
 import { useProgress } from "./hooks/useProgress";
+import { usePack } from "./hooks/usePack";
 import Chip from "./components/Chip";
 import Card from "./components/Card";
 import Tabs from "./components/Tabs";
@@ -14,7 +15,6 @@ import DailyReview from "./components/DailyReview";
 import MouseAndCheese from "./components/MouseAndCheese";
 import MiniDialogues from "./components/MiniDialogues";
 import Button from "./components/Button";
-import { getPack } from "./data/packs";
 import { generateDailyActivities } from "./utils/dailyActivities";
 
 // Root: maneja auth y solo monta AppShell cuando hay usuario
@@ -56,7 +56,7 @@ function AppShell({ user }) {
   if (!progress) return <div style={{ padding:16 }}>Sin datos de progreso.</div>;
 
   const lang = progress.settings?.narrationMode || 'it';
-  const pack = getPack(lang);
+  const { pack, loading: packLoading, error: packError } = usePack(lang);
 
   // Handlers
   const onFlashcardsComplete = () => { incrementCompletion("flashcards"); awardXP(20); alert("¡Flashcards listas!"); };
@@ -95,6 +95,16 @@ function AppShell({ user }) {
         </header>
         <main className="max-w-6xl mx-auto p-4">
           <Tabs tabs={tabs} value={tab} onChange={setTab} />
+          {packLoading && (
+            <p className="mt-4 text-sm text-neutral-600 dark:text-neutral-300">
+              Cargando vocabulario desde la API…
+            </p>
+          )}
+          {packError && (
+            <p className="mt-4 text-sm text-amber-700 dark:text-amber-300">
+              No se pudo cargar el vocabulario remoto ({packError.message}). Usando datos locales.
+            </p>
+          )}
           {tab === "dashboard" && <Dashboard progress={progress} />}
           {tab === "flash" && (
             <Flashcards
@@ -158,7 +168,7 @@ function AppShell({ user }) {
               <p className="text-sm">Aprender 5 palabras y 1 partida del juego.</p>
             </Card>
             <Card title="Acerca del paquete" subtitle="Personalizable">
-              <p className="text-sm">Edita vocabulario en src/data/packs.js.</p>
+              <p className="text-sm">Edita vocabulario en src/data/packs.json (la API usa el mismo archivo).</p>
             </Card>
           </section>
         </main>

--- a/src/data/packs.js
+++ b/src/data/packs.js
@@ -1,44 +1,11 @@
-const PACKS = {
-  it: [
-    { it: 'ciao', es: 'hola' },
-    { it: 'grazie', es: 'gracias' },
-    { it: 'per favore', es: 'por favor' },
-    { it: 'prego', es: 'de nada' },
-    { it: 'acqua', es: 'agua' },
-    { it: 'pane', es: 'pan' },
-    { it: 'formaggio', es: 'queso' },
-    { it: 'latte', es: 'leche' },
-    { it: 'ciao, come stai?', es: 'hola, ¿cómo estás?' },
-    { it: 'mi chiamo...', es: 'me llamo...' },
-  ],
-  fr: [
-    { fr: 'bonjour', es: 'hola' },
-    { fr: 'merci', es: 'gracias' },
-    { fr: "s'il vous plaît", es: 'por favor' },
-    { fr: 'de rien', es: 'de nada' },
-    { fr: 'eau', es: 'agua' },
-    { fr: 'pain', es: 'pan' },
-    { fr: 'fromage', es: 'queso' },
-    { fr: 'lait', es: 'leche' },
-    { fr: 'comment ça va?', es: '¿cómo estás?' },
-    { fr: "je m'appelle...", es: 'me llamo...' },
-  ],
-  en: [
-    { en: 'hello', es: 'hola' },
-    { en: 'thank you', es: 'gracias' },
-    { en: 'please', es: 'por favor' },
-    { en: "you're welcome", es: 'de nada' },
-    { en: 'water', es: 'agua' },
-    { en: 'bread', es: 'pan' },
-    { en: 'cheese', es: 'queso' },
-    { en: 'milk', es: 'leche' },
-    { en: 'hello, how are you?', es: 'hola, ¿cómo estás?' },
-    { en: 'my name is...', es: 'me llamo...' },
-  ],
-}
+import PACKS from "./packs.json";
 
 export function getPack(lang) {
-  return PACKS[lang] || []
+  return PACKS[lang] || [];
 }
 
-export default PACKS
+export function getAvailableLanguages() {
+  return Object.keys(PACKS);
+}
+
+export default PACKS;

--- a/src/data/packs.json
+++ b/src/data/packs.json
@@ -1,0 +1,38 @@
+{
+  "it": [
+    { "it": "ciao", "es": "hola" },
+    { "it": "grazie", "es": "gracias" },
+    { "it": "per favore", "es": "por favor" },
+    { "it": "prego", "es": "de nada" },
+    { "it": "acqua", "es": "agua" },
+    { "it": "pane", "es": "pan" },
+    { "it": "formaggio", "es": "queso" },
+    { "it": "latte", "es": "leche" },
+    { "it": "ciao, come stai?", "es": "hola, ¿cómo estás?" },
+    { "it": "mi chiamo...", "es": "me llamo..." }
+  ],
+  "fr": [
+    { "fr": "bonjour", "es": "hola" },
+    { "fr": "merci", "es": "gracias" },
+    { "fr": "s'il vous plaît", "es": "por favor" },
+    { "fr": "de rien", "es": "de nada" },
+    { "fr": "eau", "es": "agua" },
+    { "fr": "pain", "es": "pan" },
+    { "fr": "fromage", "es": "queso" },
+    { "fr": "lait", "es": "leche" },
+    { "fr": "comment ça va?", "es": "¿cómo estás?" },
+    { "fr": "je m'appelle...", "es": "me llamo..." }
+  ],
+  "en": [
+    { "en": "hello", "es": "hola" },
+    { "en": "thank you", "es": "gracias" },
+    { "en": "please", "es": "por favor" },
+    { "en": "you're welcome", "es": "de nada" },
+    { "en": "water", "es": "agua" },
+    { "en": "bread", "es": "pan" },
+    { "en": "cheese", "es": "queso" },
+    { "en": "milk", "es": "leche" },
+    { "en": "hello, how are you?", "es": "hola, ¿cómo estás?" },
+    { "en": "my name is...", "es": "me llamo..." }
+  ]
+}

--- a/src/hooks/usePack.js
+++ b/src/hooks/usePack.js
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { fetchPack } from "../services/packsApi";
+import { getPack as getLocalPack } from "../data/packs";
+
+export function usePack(lang) {
+  const [pack, setPack] = useState(() => getLocalPack(lang));
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let isMounted = true;
+
+    setPack(getLocalPack(lang));
+    setError(null);
+
+    async function load() {
+      setLoading(true);
+      try {
+        const remotePack = await fetchPack(lang, { signal: controller.signal });
+        if (!isMounted) return;
+        setPack(remotePack);
+        setError(null);
+      } catch (err) {
+        if (!isMounted || err.name === "AbortError") return;
+        setError(err);
+        setPack(getLocalPack(lang));
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [lang]);
+
+  return { pack, loading, error };
+}

--- a/src/services/packsApi.js
+++ b/src/services/packsApi.js
@@ -1,0 +1,57 @@
+const DEFAULT_BASE_URL = "http://localhost:4000";
+
+function buildBaseUrl() {
+  if (typeof import.meta !== "undefined" && import.meta.env?.VITE_PACKS_API_URL) {
+    const envUrl = import.meta.env.VITE_PACKS_API_URL;
+    return envUrl.endsWith("/") ? envUrl.slice(0, -1) : envUrl;
+  }
+  return DEFAULT_BASE_URL;
+}
+
+const API_BASE_URL = buildBaseUrl();
+
+export async function fetchPack(lang, { signal } = {}) {
+  const response = await fetch(`${API_BASE_URL}/packs/${encodeURIComponent(lang)}`, {
+    signal,
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (response.status === 404) {
+    throw new Error(`Paquete "${lang}" no encontrado en la API`);
+  }
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Error solicitando el paquete "${lang}": ${text || response.statusText}`);
+  }
+
+  const body = await response.json();
+  const words = Array.isArray(body.words) ? body.words : body;
+  return words;
+}
+
+export async function fetchAvailableLanguages({ signal } = {}) {
+  const response = await fetch(`${API_BASE_URL}/packs`, {
+    signal,
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Error solicitando listado de paquetes: ${text || response.statusText}`);
+  }
+
+  const body = await response.json();
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body.languages)) return body.languages;
+  if (Array.isArray(body.available)) return body.available;
+  return Object.keys(body);
+}
+
+export function getApiBaseUrl() {
+  return API_BASE_URL;
+}


### PR DESCRIPTION
## Summary
- add a lightweight HTTP server that exposes `/packs` and `/packs/:lang` based on the shared vocabulary data
- share the vocabulary source via `src/data/packs.json` and add a React hook/service to fetch remote data with graceful fallbacks
- document how to launch the API alongside the SPA and surface remote loading status in the UI

## Testing
- npm test
- node -e 'const server = require("./server"); server.listen(0, async () => { const { port } = server.address(); const res = await fetch(`http://localhost:${port}/packs/it`); const json = await res.json(); console.log(JSON.stringify(json)); server.close(); });'

------
https://chatgpt.com/codex/tasks/task_e_68c97be5b6508331ad21779099afd0e1