### PR TITLE
Adjust deploy workflow paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,12 +23,10 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: lingua-avventura/package-lock.json
+          cache-dependency-path: package-lock.json
       - name: Install deps
-        working-directory: lingua-avventura
         run: npm ci
       - name: Build
-        working-directory: lingua-avventura
         env:
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
@@ -36,7 +34,7 @@ jobs:
         run: npm run build
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: lingua-avventura/dist
+          path: dist
   deploy:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- update the GitHub Pages deploy workflow to use the root package-lock for caching
- run npm commands from the repository root and upload the dist artifact for deployment

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d1f4f38b648331bf5c9e2fc321c3dc