### PR TITLE
Avoid hitting packs API when no URL is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ SPA gamificada para aprender idiomas (UI en español) con minijuego tipo Snake (
 ## Desarrollo local
 ```bash
 npm install
-npm run api   # expone la API básica en http://localhost:4000
+npm run api   # opcional: expone la API básica en http://localhost:4000
 npm run dev   # en otra terminal, levanta la SPA
 ```
 
-La aplicación intenta consumir la API de vocabulario en `VITE_PACKS_API_URL` (por defecto `http://localhost:4000`).
-Si la API no está disponible, se mantiene el paquete local definido en `src/data/packs.json`.
+Si defines la variable `VITE_PACKS_API_URL` (por ejemplo `http://localhost:4000`), la aplicación intentará consumir esa API de vocabulario.
+Si la API no está disponible o no defines la variable, se mantiene el paquete local definido en `src/data/packs.json`.
 
 ## Configuración de Supabase
 


### PR DESCRIPTION
## Summary
- avoid calling the packs REST API when VITE_PACKS_API_URL is not set so the app falls back to local data quietly
- suppress noisy dev warnings for the expected REST_NOT_CONFIGURED case
- document that the local API server is optional and requires setting VITE_PACKS_API_URL

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1fa01fb78833192c213ca24c0e14d