### PR TITLE
Fix backend detection when Supabase config loads later

### DIFF
--- a/src/services/dataService.js
+++ b/src/services/dataService.js
@@ -8,9 +8,28 @@ import {
   deleteUserState,
 } from "./supabase";
 
-const configuredBackend = (import.meta.env?.VITE_BACKEND || "").toLowerCase();
-const BACKEND = configuredBackend || (isSupabaseConfigured() ? "supabase" : "local");
-const LS_KEY  = "lingua_avventura_progress_v2";
+const LS_KEY = "lingua_avventura_progress_v2";
+
+function readRuntimeBackendPreference() {
+  const env =
+    (typeof import.meta !== "undefined" && import.meta.env?.VITE_BACKEND) ??
+    (typeof globalThis !== "undefined" &&
+      (globalThis.__ENV__?.VITE_BACKEND ||
+        globalThis.__APP_ENV__?.VITE_BACKEND ||
+        globalThis.__APP_CONFIG__?.VITE_BACKEND)) ??
+    (typeof process !== "undefined" ? process.env?.VITE_BACKEND : undefined);
+
+  if (!env) return "";
+  const normalized = String(env).trim().toLowerCase();
+  if (normalized === "supabase" || normalized === "local") return normalized;
+  return "";
+}
+
+function resolveBackend() {
+  const configured = readRuntimeBackendPreference();
+  if (configured) return configured;
+  return isSupabaseConfigured() ? "supabase" : "local";
+}
 
 function todayStr(){
   const d = new Date();
@@ -68,7 +87,8 @@ async function createSupabaseBackend() {
 }
 
 async function backendFactory(){
-  if (BACKEND === "supabase") return await createSupabaseBackend();
+  const backend = resolveBackend();
+  if (backend === "supabase") return await createSupabaseBackend();
   return createLocalBackend();
 }
 


### PR DESCRIPTION
## Summary
- compute the selected backend at runtime so Supabase credentials injected after startup are detected
- support reading VITE_BACKEND from runtime config sources before falling back to Supabase auto-detection

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d21891d38c8331a7127fa742644431