### PR TITLE
Fix Supabase config loading on GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-node_modules/
-dist/
-
-# Optional npm cache & logs
-npm-debug.log*
+node_modules
 .DS_Store
+dist
+.env.local
 .env
-
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+public/runtime-env.js

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ VITE_PACKS_API_URL=http://localhost:4000   # opcional (servidor Node local)
 
 Para producción (GitHub Pages) las variables se inyectan en build mediante *GitHub Secrets* (no existe `.env` en tiempo de ejecución). Ver sección siguiente.
 
+Durante `npm run dev`/`npm run build` se genera automáticamente `public/runtime-env.js` a partir de las variables disponibles. Ese archivo **no** se versiona (está en `.gitignore`) y queda incluido en el build final para que la SPA pueda leer la configuración en tiempo de ejecución.
+
 ## Build
 ```bash
 npm run build

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script type="module" src="/runtime-env.js"></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "description": "Juego de aventura interactiva para aprender idiomas.",
   "scripts": {
+    "predev": "node scripts/write-runtime-env.js",
+    "prebuild": "node scripts/write-runtime-env.js",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/scripts/write-runtime-env.js
+++ b/scripts/write-runtime-env.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const OUTPUT_FILE = path.resolve(__dirname, '..', 'public', 'runtime-env.js');
+
+const envKeys = [
+  'VITE_SUPABASE_URL',
+  'VITE_SUPABASE_ANON_KEY',
+  'VITE_SUPABASE_PROGRESS_TABLE',
+  'VITE_PACKS_API_URL',
+  'VITE_PACKS_API_ALLOW_LOOPBACK',
+  'VITE_ADMIN_EMAILS',
+  'VITE_BACKEND'
+];
+
+const collected = {};
+for (const key of envKeys) {
+  const value = process.env[key];
+  if (value != null && String(value).trim() !== '') {
+    collected[key] = String(value);
+  }
+}
+
+const banner = '// Archivo autogenerado por scripts/write-runtime-env.js\n';
+const payload = Object.keys(collected).length ? JSON.stringify(collected, null, 2) : '{}';
+const body = `window.__ENV__ = Object.assign(window.__ENV__ || {}, ${payload});\n`;
+
+try {
+  fs.mkdirSync(path.dirname(OUTPUT_FILE), { recursive: true });
+  fs.writeFileSync(OUTPUT_FILE, banner + body);
+  if (Object.keys(collected).length) {
+    console.log('[runtime-env] runtime-env.js generado con claves:', Object.keys(collected).join(', '));
+  } else {
+    console.log('[runtime-env] runtime-env.js generado sin variables (stub vacío).');
+  }
+} catch (err) {
+  console.error('[runtime-env] Error escribiendo runtime-env.js', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- generate a runtime env script with Supabase credentials before dev/build so static deployments can read them
- load the generated runtime env script in `index.html` and ignore the output file from git
- document the new workflow for GitHub Pages builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5d6c71df08331bbd8314e45ddf7af